### PR TITLE
Event creation date

### DIFF
--- a/api/api/models/event.py
+++ b/api/api/models/event.py
@@ -24,6 +24,7 @@ class Event(db.Model):
     header_image = db.Column(db.String, default="static/posts/default.png") #can be changed if we get a default event picture
     tags = db.relationship("PostTag", secondary=events_tags)
     facebook_link = db.Column(db.String)
+    event_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
 
     
 
@@ -43,5 +44,6 @@ class Event(db.Model):
             "header_image": self.header_image,
             "committee_id": self.committee_id,
             "tags": [t.to_dict() for t in self.tags],
-            "facebook_link": self.facebook_link
+            "facebook_link": self.facebook_link,
+            "event_date": self.event_date
         }

--- a/api/api/models/event.py
+++ b/api/api/models/event.py
@@ -5,7 +5,7 @@ from api.models.post_tag import PostTag
 
 
 #Association table for tags and events
-events_tags = db.Table('eventsTags', db.Model.metadata,
+events_tags = db.Table('event_Tags', db.Model.metadata,
     db.Column('event_id', db.Integer, db.ForeignKey('event.id')),
     db.Column('tag_id', db.Integer, db.ForeignKey('post_tag.id'))
 )
@@ -24,7 +24,8 @@ class Event(db.Model):
     header_image = db.Column(db.String, default="static/posts/default.png") #can be changed if we get a default event picture
     tags = db.relationship("PostTag", secondary=events_tags)
     facebook_link = db.Column(db.String)
-    event_date = db.Column(db.DateTime, default=datetime.datetime.utcnow)
+    event_date = db.Column(db.DateTime, default=datetime.datetime.utcnow())
+    end_date = db.Column(db.DateTime, default=datetime.datetime.utcnow() + datetime.timedelta(hours=5))
 
     
 
@@ -45,5 +46,6 @@ class Event(db.Model):
             "committee_id": self.committee_id,
             "tags": [t.to_dict() for t in self.tags],
             "facebook_link": self.facebook_link,
-            "event_date": self.event_date
+            "event_date": self.event_date,
+            "end_date": self.end_date
         }

--- a/api/api/resources/event.py
+++ b/api/api/resources/event.py
@@ -206,7 +206,7 @@ def get_events():
 
 def add_event(request):
     params = json.loads(request.form.get('data'))
-    e = Event(title=params["title"], date=datetime.strptime(params["date"], ISO_DATE_DEF),
+    e = Event(title=params["title"], event_date=datetime.strptime(params["date"], ISO_DATE_DEF),
               body=params["body"], location=params["location"], committee_id=params["committee_id"], facebook_link=params["facebook_link"],
               body_en=params["body_en"], title_en=params["title_en"])
     if "header_image" in request.files:

--- a/api/api/resources/event.py
+++ b/api/api/resources/event.py
@@ -149,13 +149,15 @@ class EventListResource(Resource):
             type: file
         - name: data
           in: body
-          description: The 'date' string is in ISO-8601 format. In JS, use Date.toISOString()
+          description: The 'date' string is in ISO-8601 format. In JS, use Date.toISOString(). The end date defaults to 5 hours after the start date, if no argument is given
           schema:
             type: object
             properties:
               committee_id:
                 type: integer
               date:
+                type: string
+              end_date:
                 type: string
               facebook_link:
                 type: string
@@ -206,7 +208,7 @@ def get_events():
 
 def add_event(request):
     params = json.loads(request.form.get('data'))
-    e = Event(title=params["title"], event_date=datetime.strptime(params["date"], ISO_DATE_DEF),
+    e = Event(title=params["title"], event_date=datetime.strptime(params["date"], ISO_DATE_DEF), end_date=params["end_time"],
               body=params["body"], location=params["location"], committee_id=params["committee_id"], facebook_link=params["facebook_link"],
               body_en=params["body_en"], title_en=params["title_en"])
     if "header_image" in request.files:

--- a/app/src/Components/Feed/Feed.jsx
+++ b/app/src/Components/Feed/Feed.jsx
@@ -47,7 +47,7 @@ const Feed = (props) => {
                         type={post.type}
                         path={`${post.type === feedTypes.POST ? '/posts/' : '/events/'}${post.id}`}
                         title={translate(post.title)}
-                        date={post.date}
+                        date={post.type === feedTypes.EVENT ? post.event_date : post.date}
                         location={post.location ?? null}
                         body={translate({ se: post.body.se.trunc(250), en: post.body.en ? post.body.en.trunc(250) : '' })}
                         headerImage={post.header_image}


### PR DESCRIPTION
Add the field `event_date` to the event model in the API, to represent _the date the event happens_. The reason for doing it this way is to be able to sort both types of feed content on the frontend without unnecessary complications in the code.

closes #143 